### PR TITLE
runit scripts based on how phusion/baseimage does business now

### DIFF
--- a/slurm-abstract/Dockerfile
+++ b/slurm-abstract/Dockerfile
@@ -36,6 +36,8 @@ RUN echo slurm:slurm | chpasswd
 # make directory structure required by Slurm nodes
 RUN mkdir -p /var/spool/slurmctld/state
 RUN chown -R slurm:slurm /var/spool/slurmctld
+RUN mkdir -p /var/spool/slurmd/state
+RUN chown -R slurm:slurm /var/spool/slurmd
 
 # make slurm sysconfig directory
 RUN mkdir -p /usr/local/etc/slurm
@@ -56,14 +58,19 @@ RUN chmod 600 /usr/local/etc/slurm/slurm.key
 # change ownership to the slurm user
 RUN chown slurm:slurm /usr/local/etc/slurm/slurm.key
 
-# set workdirectory to something sane
-WORKDIR /home/xenon/
-
 # add a test job script
 ADD test-slurm.job /home/xenon/test-slurm.job
 RUN chown xenon:xenon /home/xenon/test-slurm.job
 
-ADD start-services.sh /etc/start-services.sh
-RUN chmod +x /etc/start-services.sh
-CMD /etc/start-services.sh
+RUN mkdir -p /etc/my_init.d/ &&\
+    mkdir /etc/service/munged && \
+    mkdir /etc/service/slurmctld && \
+    mkdir /etc/service//slurmd
+COPY munged.sh /etc/service/munged/run
+COPY slurmctld.sh /etc/service/slurmctld/run
+COPY slurmd.sh /etc/service/slurmd/run
 
+# set workdirectory to something sane
+WORKDIR /home/xenon/
+
+CMD ["/sbin/my_init"]

--- a/slurm-abstract/munged.sh
+++ b/slurm-abstract/munged.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /sbin/setuser munge /usr/sbin/munged --foreground > /var/log/munged.out.log 2> /var/log/munged.err.log

--- a/slurm-abstract/slurmctld.sh
+++ b/slurm-abstract/slurmctld.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+mkdir -p /run/slurm
+chown -R slurm:root /run/slurm
+mkdir -p /var/log/slurm
+chown -R slurm:root /var/log/slurm
+mkdir -p /var/spool/slurm
+exec /sbin/setuser slurm /usr/sbin/slurmctld -D -c -vvvv > /var/log/slurm/slurmctld.out.log 2> /var/log/slurm/slurmctld.err.log

--- a/slurm-abstract/slurmd.sh
+++ b/slurm-abstract/slurmd.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+NODE=${SLURM_NODE_NAME:-slurm-worker-0}
+
+mkdir -p /run/slurm/
+chown -R slurm:root /run/slurm
+mkdir -p /var/log/slurm
+chown -R slurm:root /var/log/slurm
+
+# intentionally run as root
+# see https://slurm.schedmd.com/quickstart_admin.html
+exec /usr/sbin/slurmd -D -N $NODE > /var/log/slurm/slurmd-${NODE}.out.log 2> /var/log/slurm/slurmd-${NODE}.err.log

--- a/slurm-packaged/Dockerfile
+++ b/slurm-packaged/Dockerfile
@@ -6,5 +6,5 @@ RUN apt-get update && \
     apt-get --no-install-recommends install -y slurm-wlm
 
 # ADD slurm.conf from context to sysconfig directory
-ADD slurm.conf /usr/local/etc/slurm/slurm.conf
+ADD slurm.conf /etc/slurm/slurm.conf
 

--- a/slurm-ssh/Dockerfile
+++ b/slurm-ssh/Dockerfile
@@ -4,6 +4,9 @@ FROM xenonmiddleware/slurm-fixture
 # become root user
 USER root
 
+# phusion/baseimage disables SSH by default... enable it
+RUN rm -f /etc/service/sshd/down
+
 # install SSH client
 RUN apt-get update && apt-get install -y openssh-server
 


### PR DESCRIPTION
Since I recently updated the version of `phusion/baseimage` at one of the higher levels of this image hierarchy (this could really stand to be turned into a multi-stage build, but it pre-dates that), these adjustments introduce proper `runit` scripts to automatically start and manage services on these images.